### PR TITLE
Moved internal modules out of the internal folder

### DIFF
--- a/src/encipherpy/_rebuild_key.py
+++ b/src/encipherpy/_rebuild_key.py
@@ -1,4 +1,4 @@
-def rebuildKey(plainText, key):
+def _rebuildKey(plainText, key):
   targetLength = len(plainText)
   keyBoundary = (len(key) - 1)
 

--- a/src/encipherpy/_string_number_convert.py
+++ b/src/encipherpy/_string_number_convert.py
@@ -1,4 +1,4 @@
-def stringToNumbers(string):
+def _stringToNumbers(string):
   alphabet = "abcdefghijklmnopqrstuvwxyz"
   numberList = []
   for letter in string.lower():
@@ -9,7 +9,7 @@ def stringToNumbers(string):
     numberList.append(number)
   return numberList
 
-def numbersToString(numbers):
+def _numbersToString(numbers):
   alphabet = "abcdefghijklmnopqrstuvwxyz"
   letterList = []
   for number in numbers:

--- a/src/encipherpy/caesar_cipher.py
+++ b/src/encipherpy/caesar_cipher.py
@@ -1,4 +1,5 @@
-from .internal.string_number_convert import stringToNumbers, numbersToString
+from _string_number_convert import _stringToNumbers as stringToNumbers
+from _string_number_convert import _numbersToString as numbersToString
 
 def caesarCipher(plainText, key):
   numberText = stringToNumbers(plainText)

--- a/src/encipherpy/vigenere_cipher.py
+++ b/src/encipherpy/vigenere_cipher.py
@@ -1,5 +1,6 @@
-from .internal.string_number_convert import stringToNumbers, numbersToString
-from encipherpy.internal.rebuild_key import rebuildKey
+from _string_number_convert import _stringToNumbers as stringToNumbers
+from _string_number_convert import _numbersToString as numbersToString
+from _rebuild_key import _rebuildKey as rebuildKey
 
 def vigenereCipher(plainText, key, encrypt = True):
   plainTextLength = len(plainText)


### PR DESCRIPTION
Moved all of the internal functions back into the main encipherpy directory.

Added a leading underscore to all internal functions, to indicate that they are internal and not meant for external use.