### PR TITLE
fixed internal module imports

### DIFF
--- a/src/encipherpy/caesar_cipher.py
+++ b/src/encipherpy/caesar_cipher.py
@@ -1,5 +1,9 @@
-from ._string_number_convert import _stringToNumbers as stringToNumbers
-from ._string_number_convert import _numbersToString as numbersToString
+try: # attempt a relative import of the required modules
+  from ._string_number_convert import _stringToNumbers as stringToNumbers
+  from ._string_number_convert import _numbersToString as numbersToString
+except: # if relative import fails, use a direct import instead
+  from _string_number_convert import _stringToNumbers as stringToNumbers
+  from _string_number_convert import _numbersToString as numbersToString
 
 def caesarCipher(plainText, key, encrypt = True):
   numberText = stringToNumbers(plainText)

--- a/src/encipherpy/rot47_cipher.py
+++ b/src/encipherpy/rot47_cipher.py
@@ -1,5 +1,9 @@
-from ._string_number_convert import _stringToAscii as stringToAscii
-from ._string_number_convert import _asciiToString as asciiToString
+try: # attempt a relative import of the required modules
+  from ._string_number_convert import _stringToAscii as stringToAscii
+  from ._string_number_convert import _asciiToString as asciiToString
+except: # if relative import fails, use a direct import instead
+  from _string_number_convert import _stringToAscii as stringToAscii
+  from _string_number_convert import _asciiToString as asciiToString
 
 def rot47(plainText):
   asciiNumbers = stringToAscii(plainText)

--- a/src/encipherpy/vigenere_cipher.py
+++ b/src/encipherpy/vigenere_cipher.py
@@ -1,6 +1,11 @@
-from ._string_number_convert import _stringToNumbers as stringToNumbers
-from ._string_number_convert import _numbersToString as numbersToString
-from ._rebuild_key import _rebuildKey as rebuildKey
+try: # attempt a relative import of the required modules
+  from ._string_number_convert import _stringToNumbers as stringToNumbers
+  from ._string_number_convert import _numbersToString as numbersToString
+  from ._rebuild_key import _rebuildKey as rebuildKey
+except: # if relative import fails, use a direct import instead
+  from _string_number_convert import _stringToNumbers as stringToNumbers
+  from _string_number_convert import _numbersToString as numbersToString
+  from _rebuild_key import _rebuildKey as rebuildKey
 
 def vigenereCipher(plainText, key, encrypt = True):
   plainTextLength = len(plainText)


### PR DESCRIPTION
fixed the internal module imports in both production and development environments. imports now function correctly in both environments without raising exceptions.

both relative and direct imports are now attempted, if the relative import fails then the direct import is used instead. this avoids the "no known parent package" error in dev environments.

modified:   src/encipherpy/caesar_cipher.py
modified:   src/encipherpy/rot47_cipher.py
modified:   src/encipherpy/vigenere_cipher.py